### PR TITLE
Feature/elements api 20191210

### DIFF
--- a/src/cfdcore_util.cpp
+++ b/src/cfdcore_util.cpp
@@ -662,8 +662,13 @@ ByteData256 CryptoUtil::MerkleHashSha256Midstate(
 /// RandomNumberUtil
 //////////////////////////////////
 std::vector<uint8_t> RandomNumberUtil::GetRandomBytes(int len) {
+#if defined(_WIN32) && defined(__GNUC__) && (__GNUC__ < 9)
+  // for mingw gcc lower 9
+  static std::mt19937 engine(static_cast<unsigned int>(time(nullptr)));
+#else
   static std::random_device rd;
   static std::mt19937 engine(rd());
+#endif
   std::vector<uint8_t> result(len);
 
   int index = 0;
@@ -683,8 +688,13 @@ std::vector<uint8_t> RandomNumberUtil::GetRandomBytes(int len) {
 }
 
 std::vector<uint32_t> RandomNumberUtil::GetRandomIndexes(uint32_t length) {
+#if defined(_WIN32) && defined(__GNUC__) && (__GNUC__ < 9)
+  // for mingw gcc lower 9
+  static std::mt19937 engine(static_cast<unsigned int>(time(nullptr)));
+#else
   static std::random_device rd;
   static std::mt19937 engine(rd());
+#endif
   std::uniform_int_distribution<> dist(0, length);
   std::vector<uint32_t> result(length);
   std::set<uint32_t> exist_value;
@@ -718,8 +728,13 @@ std::vector<uint32_t> RandomNumberUtil::GetRandomIndexes(uint32_t length) {
 }
 
 bool RandomNumberUtil::GetRandomBool(std::vector<bool> *random_cache) {
+#if defined(_WIN32) && defined(__GNUC__) && (__GNUC__ < 9)
+  // for mingw gcc lower 9
+  static std::mt19937 engine(static_cast<unsigned int>(time(nullptr)));
+#else
   static std::random_device rd;
   static std::mt19937 engine(rd());
+#endif
   if (random_cache == nullptr) {
     throw CfdException(kCfdIllegalArgumentError, "GetRandomBool error.");
   }


### PR DESCRIPTION
## 関連Issue

<!--
このPRが、ZenHubのどのIssueに紐づいているかを記載する
  - ZenHubのURL
-->
- https://app.zenhub.com/workspaces/cfd-5cdbe88f0f84751dcd8fd7ab/issues/cryptogarageinc/btclib-sandbox/1043
- https://app.zenhub.com/workspaces/cfd-5cdbe88f0f84751dcd8fd7ab/issues/cryptogarageinc/btclib-sandbox/1044

## 概要

<!--
- 追加機能の概要を記載
- 前提が共有されていない場合は、  
  なぜこの変更をして、  
  どう解決されるのかも併せて記載する

- 必要であれば、以下のような詳細についても記載する
  - 以下の観点で、レビューアーにわかるように技術的な変更点の概要を記載
    - 何をどう変更したか
    - どういった手法を採用したか  
      （e.g. パス探索については、幅優先探索を採用した）
    - 外部システムとのI/F変更
    - など
-->

- 1043: cfd-api, capi追加
  - cfd: AddressFactoryにGetAddressByLockingScript 追加
  - c-api: CfdGetConfidentialTxInfo, CfdGetAddressFromLockingScript を追加
- 1044: cfd-go
  - CfdGoGetConfidentialTxInfo, CfdGoGetAddressFromLockingScript を追加
  - 乱数不具合修正
    - cfd-core: Windows mingwで乱数生成の不具合があったため、ifdefで処理差し替え。
    - https://cpprefjp.github.io/reference/random/random_device.html

## 使い方

<!-- 
- PRの動作確認方法
  - 動作確認が必要なタスクについては、必要なコマンドなどを記載
  - 必要なければ、無記載で良い
-->

```bash
npm run check_all
```

## 今回保留した項目とTODO

<!--
- 箇条書きで保留した項目があれば、記載
  - 保留項目が直近の対応が必要な場合、対応チケットを作成して記載

記載例
- 〇〇の計算ロジックの本実装 #0000
-->

- Witness txのチェックはcfd-goのみに記載。(blind tx)

## 確認項目

**PRを出した人**
<!-- PRを出す前後で確認する項目 -->

- [x] チェックスクリプトでチェックを実施した <!-- npm run check -->
- [x] 正常にビルドできた
- [x] 関連チケットに実績をつけた
- [x] ZenHubでPRとIssueを関連付けた
- [x] ZenHubのIssueを `Review/QA` Pipelineに移した

**レビューする人**
<!-- レビューをする前後で確認する項目 -->
- [x] 関連チケットにレビュー実績をつけた

## 備考

<!--
- 実装に関する悩み（AにするかBにするか迷ったがAにしたや、こうしたかったけどできなかったなど）があれば記載
-->
- 関連のあるレポジトリ
  - cfd <- cfd-go : 追加API参照のため、ブランチ記載一時変更
    - cfd-coreの修正は依存が無いため、ブランチ記載変更なし