### PR TITLE
Bug/fix segfault on der decode

### DIFF
--- a/src/cfdcore_util.cpp
+++ b/src/cfdcore_util.cpp
@@ -489,6 +489,12 @@ ByteData CryptoUtil::ConvertSignatureToDer(
 ByteData CryptoUtil::ConvertSignatureFromDer(
     const ByteData &der_data, SigHashType *sighash_type) {
   std::vector<uint8_t> der_sig = der_data.GetBytes();
+
+  if (der_sig.size() == 0) {
+    warn(CFD_LOG_SOURCE, "Empty signature.");
+    throw CfdException(kCfdIllegalStateError, "der decode error.");
+  }
+
   if (der_sig.size() <= (EC_SIGNATURE_DER_MAX_LEN + 1)) {
     uint8_t sighash_byte = der_sig[der_sig.size() - 1];
     der_sig.resize(der_sig.size() - 1);

--- a/test/test_cryptoutil.cpp
+++ b/test/test_cryptoutil.cpp
@@ -471,6 +471,17 @@ TEST(CryptoUtil, ConvertSignatureFromDer) {
   EXPECT_STREQ(signature.GetHex().c_str(), hex_sig.c_str());
 }
 
+TEST(CryptoUtil, ConvertSignatureFromDerHexEmpty) {
+  try {
+    ByteData hex_sig;
+    ByteData byte_data = CryptoUtil::ConvertSignatureFromDer(hex_sig, nullptr);
+  } catch (const cfd::core::CfdException &cfd_except) {
+    EXPECT_STREQ(cfd_except.what(), "der decode error.");
+    return;
+  }
+  ASSERT_TRUE(false);
+}
+
 // Base64 encode tool
 // https://cryptii.com/pipes/base64-to-hex
 // EncodeBase64----------------------------------------------------------------


### PR DESCRIPTION
## 関連Issue

NA

## 概要

Passing an empty signature to the ConvertFromDer method triggers a segmentation fault.

## 使い方

NA

## 今回保留した項目とTODO

## 確認項目

**PRを出した人**

- [ ] チェックスクリプトでチェックを実施した <!-- npm run check -->
- [X] 正常にビルドできた
- [ ] 関連チケットに実績をつけた
- [ ] ZenHubでPRとIssueを関連付けた
- [ ] ZenHubのIssueを `Review/QA` Pipelineに移した

**レビューする人**
<!-- レビューをする前後で確認する項目 -->
- [ ] 関連チケットにレビュー実績をつけた

## 備考

Maybe nice to check if there is no other segmentation fault possibilities.
