### PR TITLE
Add optimized batch function for computing schnorr sig point

### DIFF
--- a/include/cfdcore/cfdcore_schnorrsig.h
+++ b/include/cfdcore/cfdcore_schnorrsig.h
@@ -1,5 +1,6 @@
 // Copyright 2020 CryptoGarage
 #include <string>
+#include <vector>
 
 #include "cfdcore/cfdcore_bytedata.h"
 #include "cfdcore/cfdcore_common.h"
@@ -287,6 +288,23 @@ class CFD_CORE_EXPORT SchnorrUtil {
   static Pubkey ComputeSigPoint(
       const ByteData256 &msg, const SchnorrPubkey &nonce,
       const SchnorrPubkey &pubkey);
+
+  /**
+   * @brief Compute the sum of signature points for a set of Schnorr signature.
+   * This enable reducing the number of EC multiplications done when computing the
+   * addition of multiple signature points. So instead of computing:
+   * S = (R_0 + X * H(X || R_0 || m_0)) + ... + (R_n + X * H(X || R_n || m_n))
+   * This function computes:
+   * S = (R_0 + ... + R_n) + X * (H(X || R_0 || m_0) + ... + H(X || R_n || m_n))
+   *
+   * @param msgs the set of messages that will be signed.
+   * @param nonces the public component of the nonces that will be used.
+   * @param pubkey the public key for which the signatures will be valid.
+   * @return Pubkey the signature point.
+   */
+  static Pubkey ComputeSigPointBatch(
+      const std::vector<ByteData256> &msgs,
+      const std::vector<SchnorrPubkey> &nonces, const SchnorrPubkey &pubkey);
 
   /**
    * @brief Verify a Schnorr signature.

--- a/test/test_schnorrsig.cpp
+++ b/test/test_schnorrsig.cpp
@@ -238,3 +238,34 @@ TEST(SchnorrPubkey, TweakTest) {
   EXPECT_EQ(exp_pk_c, pk_c12.GetHex());
   EXPECT_EQ(exp_sk_c, sk_c.GetHex());
 }
+
+TEST(SchnorrUtil, ComputeSigPointBatch) {
+  std::vector<ByteData256> data = {
+      ByteData256(
+          "e48441762fb75010b2aa31a512b62b4148aa3fb08eb0765d76b252559064a614"),
+      ByteData256(
+          "80a1c2125d13d6b2d639f2da507772040719d36c6228ec141befd1aecb901b17"),
+      ByteData256(
+          "375a7aec74bba181ffca89ef03bd8a10d7ddae7813190d4616652d9e91bcff20"),
+  };
+
+  std::vector<SchnorrPubkey> nonces = {
+      SchnorrPubkey(
+          "4d18084bb47027f47d428b2ed67e1ccace5520fdc36f308e272394e288d53b6d"),
+      SchnorrPubkey(
+          "f14d7e54ff58c5d019ce9986be4a0e8b7d643bd08ef2cdf1099e1a457865b547"),
+      SchnorrPubkey(
+          "dc82121e4ff8d23745f3859e8939ecb0a38af63e6ddea2fff97a7fd61a1d2d54")};
+
+  std::vector<Pubkey> sig_points;
+  for (size_t i = 0; i < data.size(); i++) {
+    sig_points.push_back(
+        SchnorrUtil::ComputeSigPoint(data[i], nonces[i], pubkey));
+  }
+  auto expected_sig_point = Pubkey::CombinePubkey(sig_points);
+
+  auto actual_sig_point =
+      SchnorrUtil::ComputeSigPointBatch(data, nonces, pubkey);
+
+  ASSERT_EQ(expected_sig_point.GetHex(), actual_sig_point.GetHex());
+}


### PR DESCRIPTION
## Linked Issue

NA

## Overview

The added function computes the sum of signature points for a set of Schnorr signature. This enable reducing the number of EC multiplications done when computing the sum of multiple signature points. So instead of computing:
   * S = (R_0 + X * H(X || R_0 || m_0)) + ... + (R_n + X * H(X || R_n || m_n))
This function computes:
   * S = (R_0 + ... + R_n) + X * (H(X || R_0 || m_0) + ... + H(X || R_n || m_n))

## How to use

See added test

## Items reserved this time, or TODO

None

## Check list

** Person who issued **
- [X] checked script <!-- npm run check -->
- [X] build successed
- [ ] Linked PullRequest and Issue

** Reviewer **
- [ ] (if necessary) Record the review results of related tickets.

## Memo

